### PR TITLE
Update CMake minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ MESSAGE("====================================================")
 
 # this is the standard deal.II search mechanism, including check for Trilinos and p4est
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.16)
 
 FIND_PACKAGE(deal.II 9.3 QUIET
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}


### PR DESCRIPTION
When building the tests in MeltPoolDG with adaflo enabled we run into https://github.com/dealii/dealii/issues/14949

If I understand correctly, the docker image we use for testing relies on Ubuntu 20.04 with CMake 3.16 by default. With this PR I wanted to check if the problem still occurs.